### PR TITLE
application: serial_lte_modem: add missing const to led_effect in led

### DIFF
--- a/applications/serial_lte_modem/src/slm_ui.h
+++ b/applications/serial_lte_modem/src/slm_ui.h
@@ -76,7 +76,7 @@ struct led_effect {
 struct led {
 	size_t id;
 	enum ui_led_state state;
-	struct led_effect *effect;
+	const struct led_effect *effect;
 	uint16_t effect_step;
 	uint16_t effect_substep;
 	uint16_t effect_loop;


### PR DESCRIPTION
This fixes a build warning which is upgraded to an error when running twister.
Now builds without warnings.

I don't know your domain well, so please make a judgement of whether the `led_effect` field in `led` was intended to be `const` or not.