### PR TITLE
TF-M ready config

### DIFF
--- a/applications/serial_lte_modem/child_image/mcuboot.conf
+++ b/applications/serial_lte_modem/child_image/mcuboot.conf
@@ -7,3 +7,9 @@ CONFIG_LOG_BACKEND_UART=n
 CONFIG_USE_SEGGER_RTT=y
 CONFIG_RTT_CONSOLE=y
 CONFIG_CONSOLE_HANDLER=n
+
+# Clean up the core for TF-M compatibility
+CONFIG_MCUBOOT_CLEANUP_ARM_CORE=y
+
+# Reduce mcuboot size to fit within a single protection area
+CONFIG_PM_PARTITION_SIZE_MCUBOOT=0x7a00

--- a/applications/serial_lte_modem/prj.conf
+++ b/applications/serial_lte_modem/prj.conf
@@ -66,6 +66,17 @@ CONFIG_IMG_MANAGER=y
 
 CONFIG_IMG_ERASE_PROGRESSIVELY=y
 
+# Placeholder partition to match the following layout:
+# +-----------------------------------------------------+
+# | 0x0: mcuboot (0x8000 - 32kB)                        |
+# | 0x8000: mcuboot_primary (0x70000 - 448kB)           |
+# | 0x78000: mcuboot_secondary (0x70000 - 448kB)        |
+# | 0xe8000: placeholder/TFM_EXTRA (0x16000 - 88kB)     |
+# | 0xfe000: settings_storage (0x2000 - 8kB)            |
+# +-----------------------------------------------------+
+CONFIG_PM_PLACEHOLDER=y
+CONFIG_PM_PARTITION_SIZE_PLACEHOLDER=0x16000
+
 # Serial DFU
 CONFIG_MCUMGR=y
 CONFIG_MCUMGR_SMP_UART=y

--- a/subsys/partition_manager/CMakeLists.txt
+++ b/subsys/partition_manager/CMakeLists.txt
@@ -49,6 +49,11 @@ endfunction()
 # Add all pm.yml files for subsystems
 # Store the preprocessed output in the binary dir of the subsystems
 # to avoid overwriting pm.yml files.
+
+if (CONFIG_PM_PLACEHOLDER)
+  ncs_add_partition_manager_config(pm.yml.placeholder)
+endif()
+
 if (CONFIG_SETTINGS_FCB OR CONFIG_SETTINGS_NVS)
   ncs_add_partition_manager_config(pm.yml.settings)
 endif()

--- a/subsys/partition_manager/Kconfig
+++ b/subsys/partition_manager/Kconfig
@@ -40,6 +40,15 @@ partition-size=0x6000
 rsource "Kconfig.template.partition_size"
 endif
 
+config PM_PLACEHOLDER
+	bool "Enable a placeholder partition in the flash storage area"
+	depends on PARTITION_MANAGER_ENABLED
+
+if PM_PLACEHOLDER
+partition=PLACEHOLDER
+partition-size=0x8000
+rsource "Kconfig.template.partition_size"
+endif
 
 if SETTINGS
 partition=SETTINGS_STORAGE

--- a/subsys/partition_manager/pm.yml.placeholder
+++ b/subsys/partition_manager/pm.yml.placeholder
@@ -1,0 +1,5 @@
+#include <autoconf.h>
+
+placeholder:
+  placement: {before: [end]}
+  size: CONFIG_PM_PARTITION_SIZE_PLACEHOLDER


### PR DESCRIPTION
* Add support for placeholder partition
* Configure the serial_lte_modem application to use a specific flash layout: 32k boot, 448k slot, 448k slot, 96k storage
* Configure the serial_lte_modem application to compile mcuboot with
  MCUBOOT_CLEANUP_ARM_CORE enabled, for TF-M compatibility
